### PR TITLE
removed additional unnecessary parameters

### DIFF
--- a/dada2-for-qiime.md
+++ b/dada2-for-qiime.md
@@ -40,7 +40,7 @@ Note: If you received the sequence data where each sample is represented in a un
 ```bash
 cd moving_pictures_tutorial-1.9.0  
 
-split_libraries_fastq.py -o slout/ -i illumina/forward_reads.fastq.gz -b illumina/barcodes.fastq.gz -m illumina/map.tsv --store_demultiplexed_fastq -r 999 -n 999 -q 0 -p 0.000001
+split_libraries_fastq.py -o slout/ -i illumina/forward_reads.fastq.gz -b illumina/barcodes.fastq.gz -m illumina/map.tsv --store_demultiplexed_fastq -n 999 -q 0
 ```
 
 ### Split sequence files on a per sample basis


### PR DESCRIPTION
Hey John, 
The -q 0 and -n 999 parameters are sufficient for this pipeline. -r and -p both use -q as a basis for defining themselves. I ran both of these processes on a data set and the md5 sums are exactly the same. 
Thanks,
Arron
